### PR TITLE
fix: update redirect to rstar327/github-stats repo

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
   "redirects": [
     {
       "source": "/",
-      "destination": "https://github.com/anuraghazra/github-readme-stats"
+      "destination": "https://github.com/rstar327/github-stats"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Update vercel.json redirect destination from anuraghazra/github-readme-stats to rstar327/github-stats

## Test plan
- [ ] Visit https://github-stats-mu-nine.vercel.app/ and verify it redirects to https://github.com/rstar327/github-stats